### PR TITLE
added check for valid api name

### DIFF
--- a/lib/before.js
+++ b/lib/before.js
@@ -41,7 +41,7 @@ module.exports = function (scope, cb) {
 	// Test naming pattern for API name (required by GraphQL)
   const NAMEPATTERN = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
   if (!NAMEPATTERN.test(scope.id)) {
-    return cb.invalid(`Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "${scope.id}" does not.`);
+    return cb.invalid('Names must match `/^[_a-zA-Z][_a-zA-Z0-9]*$/` but `' + scope.id + '` does not.');
   }
 
   // Validate optional attribute arguments.

--- a/lib/before.js
+++ b/lib/before.js
@@ -38,6 +38,12 @@ module.exports = function (scope, cb) {
     return cb.invalid('Usage: `$ strapi generate api <myAPI> [attribute|attribute:type ...]`');
   }
 
+	// Test naming pattern for API name (required by GraphQL)
+  const NAMEPATTERN = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
+  if (!NAMEPATTERN.test(scope.id)) {
+    return cb.invalid(`Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "${scope.id}" does not.`);
+  }
+
   // Validate optional attribute arguments.
   let attributes = scope.attributes;
   const invalidAttributes = [];


### PR DESCRIPTION
This is supposed to solve https://github.com/wistityhq/strapi/issues/35.
It uses the same regex pattern as GraphQL.